### PR TITLE
Bump build num

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
No change other than building the library via cloned repository.  The 0
build was mistakenly built out of the repo used to create the exempi
package in the first place.